### PR TITLE
Add commit and PR creation skills with skillsaw linting

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,26 @@
+name: Verify
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Run verify
+        run: make verify
+
+      - name: Upload skillsaw summary
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: skillsaw-summary
+          path: _artifacts/skillsaw-summary.html
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Binary
 bin/
 .build/
+_artifacts/
 
 # Log files
 *.log

--- a/.skillsaw.yaml
+++ b/.skillsaw.yaml
@@ -1,0 +1,193 @@
+# skillsaw configuration
+# https://github.com/stbenjam/skillsaw
+version: "0.10.1"
+rules:
+  # Skill just have valid name, description and kubernetes additionally
+  # enforces `license` and `copyright`.
+  agentskill-valid:
+    enabled: auto
+    severity: error
+    required-fields:
+      - license
+    required-metadata:
+      - copyright
+
+  # Skill name must be lowercase with hyphens and match directory name
+  agentskill-name:
+    enabled: auto
+    severity: error
+
+  # Skill description should be meaningful and within length limits
+  agentskill-description:
+    enabled: auto
+    severity: warning
+
+  # Skill directories should only contain recognized subdirectories (stricter than spec)
+  agentskill-structure:
+    enabled: false
+    severity: warning
+    # allowed_dirs:
+    #   - assets
+    #   - evals
+    #   - references
+    #   - scripts
+
+  # Require evals/evals.json for each skill (opt-in)
+  agentskill-evals-required:
+    enabled: false
+    severity: warning
+
+  # Validate evals/evals.json format when present
+  agentskill-evals:
+    enabled: auto
+    severity: warning
+
+  # Instruction files (AGENTS.md, CLAUDE.md, GEMINI.md) must be valid and non-empty
+  instruction-file-valid:
+    enabled: auto
+    severity: warning
+
+  # Import references (@path) in CLAUDE.md and GEMINI.md must point to existing files
+  instruction-imports-valid:
+    enabled: auto
+    severity: warning
+
+  # Warn when instruction or config files exceed recommended token limits
+  context-budget:
+    enabled: auto
+    severity: warning
+    # limits:
+    #   agents-md:
+    #     warn: 6000
+    #     error: 12000
+    #   claude-md:
+    #     warn: 6000
+    #     error: 12000
+    #   gemini-md:
+    #     warn: 6000
+    #     error: 12000
+    #   instruction:
+    #     warn: 4000
+    #     error: 8000
+    #   skill:
+    #     warn: 3000
+    #     error: 6000
+    #   command:
+    #     warn: 2000
+    #     error: 4000
+    #   agent:
+    #     warn: 2000
+    #     error: 4000
+    #   rule:
+    #     warn: 2000
+    #     error: 4000
+    #   skill-description:
+    #     warn: 200
+    #     error: 500
+    #   command-description:
+    #     warn: 200
+    #     error: 500
+
+  # Detect hedging, vague, and non-actionable language in instruction files
+  content-weak-language:
+    enabled: auto
+    severity: warning
+
+  # Detect tautological instructions that the model already follows by default
+  content-tautological:
+    enabled: auto
+    severity: warning
+
+  # Detect critical instructions in the middle of files where LLM attention is lowest
+  content-critical-position:
+    enabled: auto
+    severity: warning
+    min-lines: 50
+
+  # Detect instructions that duplicate .editorconfig, ESLint, Prettier, or tsconfig settings
+  content-redundant-with-tooling:
+    enabled: auto
+    severity: warning
+
+  # Check if instruction count in a file exceeds LLM instruction budget (~150)
+  content-instruction-budget:
+    enabled: auto
+    severity: warning
+
+  # Detect prohibitions without a positive alternative (agent has no path forward)
+  content-negative-only:
+    enabled: auto
+    severity: warning
+
+  # Warn about markdown sections longer than ~500 tokens
+  content-section-length:
+    enabled: auto
+    severity: info
+    # max-tokens: 500
+
+  # Detect likely contradictions within instruction files using keyword-pair heuristics
+  content-contradiction:
+    enabled: auto
+    severity: warning
+
+  # Score instruction files on actionability (verb density, commands, file references)
+  content-actionability-score:
+    enabled: auto
+    severity: info
+
+  # Check that instruction files are organized into cognitive chunks with headings
+  content-cognitive-chunks:
+    enabled: auto
+    severity: info
+
+  # Detect potential API keys, tokens, and passwords in instruction files
+  content-embedded-secrets:
+    enabled: auto
+    severity: error
+
+  # Detect banned or deprecated model names, APIs, and custom patterns
+  content-banned-references:
+    enabled: auto
+    severity: warning
+    # banned: []
+    # skip-builtins: false
+
+  # Detect inconsistent terminology across instruction files (e.g., mixing 'directory' and 'folder')
+  content-inconsistent-terminology:
+    enabled: auto
+    severity: info
+
+  # Detect markdown links where the target file does not exist
+  content-broken-internal-reference:
+    enabled: auto
+    severity: warning
+
+  # Detect bare path-like strings not wrapped in markdown link syntax
+  content-unlinked-internal-reference:
+    enabled: auto
+    severity: info
+    # patterns:
+    #   - "./**/*.*"
+    #   - "references/**/*.md"
+
+  # Detect TODO markers, bracket placeholders, and unfilled template text
+  content-placeholder-text:
+    enabled: auto
+    severity: warning
+
+# Load custom rules from these files
+custom-rules: []
+
+# Exclude patterns (glob format)
+# Use exclude: [] to disable all excludes including defaults
+exclude:
+    # - "**/template/**"
+    # - "**/templates/**"
+    # - "**/_template/**"
+
+# Additional markdown files to run content rules on (glob format)
+content-paths:
+  - skills/**
+
+# Treat warnings as errors
+strict: true

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+CONTAINER_ENGINE ?= $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
+SKILLSAW_IMAGE ?= ghcr.io/stbenjam/skillsaw:0.10.1
+PROJECT_DIR ?= $(CURDIR)
+ARTIFACTS ?= $(PROJECT_DIR)/_artifacts
+
+.PHONY: verify
+verify: verify-skills-lint
+
+.PHONY: verify-skills-lint
+verify-skills-lint: ## Lint agent skills with skillsaw
+	$(_skills_lint_recipe)
+
+# Validates skills against https://agentskills.io/specification
+define _skills_lint_recipe
+mkdir -p $(ARTIFACTS)
+$(CONTAINER_ENGINE) run --rm -v $(PROJECT_DIR):/workspace:Z -v $(ARTIFACTS):/out:Z $(SKILLSAW_IMAGE) --output /out/skillsaw-summary.html
+endef

--- a/skills/README.md
+++ b/skills/README.md
@@ -16,7 +16,8 @@ Skills are organized into subdirectories, each representing a distinct skill. A 
 
 ## Available Skills
 
-*(None yet. Add your skill here!)*
+- [`commit-from-changes`](./commit-from-changes/SKILL.md): Stage and commit changes with a Kubernetes-style commit message.
+- [`create-pr-from-template`](./create-pr-from-template/SKILL.md): Create a GitHub pull request from the current branch using the repository's PR template when available.
 
 ## Contributing
 

--- a/skills/commit-from-changes/SKILL.md
+++ b/skills/commit-from-changes/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: commit-from-changes
+description: Stage and commit changes with a Kubernetes-style commit message
+user-invocable: true
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+## Name
+
+commit-from-changes:commit-from-changes
+
+## Synopsis
+
+Stage and commit changes with a Kubernetes-style commit message.
+
+## Description
+
+Generates a commit for the current changes following Kubernetes commit message conventions. Stages all changes if nothing is staged, reviews the diff, and produces a commit message with a capitalized imperative subject line under 72 characters and a body that explains the reason for the change.
+
+## Implementation
+
+Generate a commit for the current changes following these rules:
+
+1. Run `git diff --cached --stat` and `git diff --stat` to understand what has changed. If nothing is staged, stage all changes with `git add -A`.
+2. Run `git diff --cached` to review the full staged diff.
+3. Generate a commit message in Kubernetes style:
+   - Subject line: start with a capitalized imperative verb (e.g., Fix, Add, Update, Remove, Refactor)
+   - Subject line should be concise (under 50 characters) and describe WHAT changed
+   - If the change is scoped to a specific component or package, prefix with it (e.g., "pkg/controller: Fix race condition in queue processing")
+   - Add a blank line after the subject
+   - Body should explain WHY the change was made if not obvious from the subject
+   - Wrap body lines at 72 characters
+4. NEVER use Co-authored-by in any commit messages
+5. Do not use GitHub keywords that automatically close issues (e.g., "Fixes #123", "Closes #456") or @mentions in commit messages
+6. Show the generated commit message to the user and ask for approval before committing
+7. Commit with the approved message using `git commit`

--- a/skills/create-pr-from-template/SKILL.md
+++ b/skills/create-pr-from-template/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: create-pr-from-template
+description: Create a GitHub pull request from the current branch
+user-invocable: true
+license: Apache-2.0
+metadata:
+  copyright: The Kubernetes Authors
+---
+
+## Name
+
+create-pr-from-template:create-pr-from-template
+
+## Synopsis
+
+Create a GitHub pull request from the current branch.
+
+## Description
+
+Creates a GitHub pull request from the current branch by analyzing commits, looking for PR templates, and generating a descriptive title and body.
+
+## Implementation
+
+1. **Check for PR templates**: Look for pull request templates in the repository at these common locations:
+   - `.github/pull_request_template.md`
+   - `.github/PULL_REQUEST_TEMPLATE.md`
+   - `.github/PULL_REQUEST_TEMPLATE/` (directory with multiple templates)
+   - `docs/pull_request_template.md`
+   - `pull_request_template.md`
+
+2. **Determine the base branch**: Use `main` as the default base branch. Check the repo's default branch if unsure.
+
+3. **Generate the PR title**: Create a concise, descriptive title from the commits on the current branch that are not on the base branch.
+
+4. **Generate the PR body**:
+   - If a PR template exists in the repo, use it as the structure and fill it in based on the changes.
+   - If no template exists, generate a clear PR description summarizing the changes.
+   - Always include the following section at the bottom of the PR body:
+
+     ```
+     ---
+     > **AI Assistance Disclosure**: This pull request was created with the assistance of AI.
+     ```
+
+5. **Create the PR**: Use `gh pr create` to create the pull request. Show the user the title and body before creating it, and ask for confirmation.


### PR DESCRIPTION
## Summary

- Add two new agent skills: `commit-from-changes` for generating
  Kubernetes-style commit messages, and `create-pr-from-template` for
  creating GitHub pull requests from the current branch.
- Add skillsaw configuration (`.skillsaw.yaml`) for validating skills
  against the AgentSkills specification.
- Add a Makefile with a `verify-skills-lint` target that runs skillsaw
  via container (podman/docker).
- Include the initial skillsaw report showing all checks passing.
- Add github action for verify steps

---
> **AI Assistance Disclosure**: This pull request was created with the assistance of AI (Claude Code by Anthropic).